### PR TITLE
Redrive messages from one queue to another

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,5 +4,6 @@
   ],
   "plugins": [
     "transform-strict-mode"
-  ]
+  ],
+  "retainLines": true
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,6 @@
 {
   "extends": "springworks/babel",
   "rules": {
+    "no-console": 0
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,2 +1,45 @@
-# node-aws-sqs-redriver
-Re-drives messages from one SQS queue to another, e.g. to re-process "dead letters"
+# AWS SQS Redriver
+Re-drives messages from one SQS queue to another, e.g. to re-process "dead letters".
+
+Meant to be triggered by an SNS notification and run on a Lambda.
+
+## Message Redriver API
+
+### `redriveMessages({ sns_event }) -> Promise`
+
+Moves messages from `source_queue_url` to `target_queue_url`, which should be defined as stringified JSON in the event `Message`.
+
+#### Example
+
+```js
+const redriver = require('./build/sqs-redriver');
+const dead_letter_queue_url = 'arn:aws:sqs:region:account-id:queuename_dlq';
+const target_queue_url = 'arn:aws:sqs:region:account-id:queuename';
+
+const queue_params = {
+  source_queue_url: 'https://queue.amazonaws.com/80398EXAMPLE/MyDLQ',
+  target_queue_url: 'https://queue.amazonaws.com/80398EXAMPLE/MyQueue',
+};
+
+// SNS Event should have Message: JSON.stringify(queue_params)
+
+redriver.redriveMessages({ sns_event: sns_event })
+      .then(() => console.log('Success!'))
+      .catch(err => console.log('Failed to redrive messages: %j', err));
+```
+
+#### IAM access to queues
+
+`source_queue_url`
+
+- sqs:ChangeMessageVisibility
+- sqs:ReceiveMessage
+- sqs:DeleteMessage
+
+`target_queue_url`
+
+- sqs:SendMessage
+
+## License
+
+MIT.

--- a/index.js
+++ b/index.js
@@ -1,0 +1,14 @@
+const redriver = require('./build/sqs-redriver');
+
+exports.handler = function(sns_event) {
+  console.log('Starting queue redrive...');
+
+  redriver.default.redriveMessages({ sns_event: sns_event })
+      .then(() => {
+        console.log('Queue redrive complete');
+      })
+      .catch(err => {
+        console.log('Queue redrive failed', err);
+      });
+};
+

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "homepage": "https://github.com/Springworks/node-aws-sqs-redriver#readme",
   "devDependencies": {
     "@springworks/test-harness": "1.4.3",
+    "aws-sdk": "2.6.3",
     "babel-cli": "6.14.0",
     "babel-core": "6.14.0",
     "babel-eslint": "6.1.2",
@@ -45,8 +46,11 @@
     "eslint-plugin-should-promised": "1.0.8",
     "eslint-plugin-springworks": "2.0.1",
     "istanbul": "0.4.5",
+    "lodash.clonedeep": "4.5.0",
     "mocha": "3.0.2",
     "semantic-release": "4.3.5"
   },
-  "dependencies": {}
+  "dependencies": {
+    "@springworks/input-validator": "4.0.24"
+  }
 }

--- a/src/sqs-instance.js
+++ b/src/sqs-instance.js
@@ -1,0 +1,3 @@
+import AWS from 'aws-sdk';
+
+export default new AWS.SQS({ apiVersion: '2012-11-05' });

--- a/src/sqs-redriver.js
+++ b/src/sqs-redriver.js
@@ -1,0 +1,125 @@
+import { validateSchema, joi } from '@springworks/input-validator';
+import sqs_instance from './sqs-instance';
+
+const deserialized_queue_params_schema = joi.object().required().keys({
+  source_queue_url: joi.string().uri().required(),
+  target_queue_url: joi.string().uri().required(),
+});
+
+const params_schema = joi.object().required().keys({
+  sns_event: joi.object().required().keys({
+    Records: joi.array().required().items(joi.object().required().keys({
+      EventVersion: joi.string().optional(),
+      EventSubscriptionArn: joi.string().optional(),
+      EventSource: joi.string().optional(),
+      Sns: joi.object().required().keys({
+        SignatureVersion: joi.string().optional(),
+        Timestamp: joi.string().optional(),
+        Signature: joi.string().optional(),
+        SigningCertUrl: joi.string().optional(),
+        MessageId: joi.string().optional(),
+        Message: joi.string().required().notes('Expected to be stringified JSON, see deserialized_queue_params_schema'),
+        MessageAttributes: joi.object().optional(),
+        Type: joi.string().optional(),
+        UnsubscribeUrl: joi.string().optional(),
+        TopicArn: joi.string().optional(),
+        Subject: joi.string().optional().allow(''),
+      }),
+    })),
+  }),
+});
+
+function validateParams(params) {
+  return validateSchema(params, params_schema);
+}
+
+function extractQueueUrls(validated_params) {
+  const queue_params = JSON.parse(validated_params.sns_event.Records[0].Sns.Message);
+  return validateSchema(queue_params, deserialized_queue_params_schema);
+}
+
+function fetchMessagesUntilEmpty({ source_queue_url, target_queue_url }) {
+  return receiveMessage({ source_queue_url })
+      .then(sqs_message => {
+        if (!sqs_message) {
+          return null;
+        }
+        return redriveMessage({ sqs_message, source_queue_url, target_queue_url })
+            .then(() => fetchMessagesUntilEmpty({ source_queue_url, target_queue_url }));
+      });
+}
+
+function redriveMessage({ sqs_message, source_queue_url, target_queue_url }) {
+  return sendMessage({ message_body: sqs_message.Body, target_queue_url })
+      .then(() => deleteMessage({ receipt_handle: sqs_message.ReceiptHandle, source_queue_url }))
+      .then(() => console.log(`Message moved from ${source_queue_url} to ${target_queue_url}`))
+      .then(() => null);
+}
+
+function receiveMessage({ source_queue_url }) {
+  return new Promise((resolve, reject) => {
+    sqs_instance.receiveMessage({
+      MaxNumberOfMessages: 1,
+      QueueUrl: source_queue_url,
+    }, (err, messages) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+
+      if (messages.length) {
+        resolve(messages[0]);
+        return;
+      }
+
+      resolve(null);
+    });
+  });
+}
+
+
+function deleteMessage({ source_queue_url, receipt_handle }) {
+  return new Promise((resolve, reject) => {
+    sqs_instance.deleteMessage({
+      ReceiptHandle: receipt_handle,
+      QueueUrl: source_queue_url,
+    }, (err, data) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve(data);
+    });
+  });
+}
+
+
+function sendMessage({ target_queue_url, message_body }) {
+  return new Promise((resolve, reject) => {
+    sqs_instance.sendMessage({
+      QueueUrl: target_queue_url,
+      MessageBody: message_body,
+    }, (err, data) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve(data);
+    });
+  });
+}
+
+const api = {
+  redriveMessages({ sns_event }) {
+    return Promise.resolve({ sns_event })
+        .then(validateParams)
+        .then(extractQueueUrls)
+        .then(fetchMessagesUntilEmpty)
+        .catch(err => {
+          console.warn('redriveMessages failed: %s', err);
+          throw err;
+        });
+  },
+};
+
+export default api;

--- a/test-util/fixtures/sns-event.json
+++ b/test-util/fixtures/sns-event.json
@@ -1,0 +1,22 @@
+{
+  "Records": [
+    {
+      "EventVersion": "1.0",
+      "EventSubscriptionArn": "arn:the:temple:knight",
+      "EventSource": "aws:sns",
+      "Sns": {
+        "SignatureVersion": "1",
+        "Timestamp": "1970-01-01T00:00:00.000Z",
+        "Signature": "EXAMPLE",
+        "SigningCertUrl": "EXAMPLE",
+        "MessageId": "95df01b4-ee98-5cb9-9903-4c221d41eb5e",
+        "Message": "{\"source_queue_url\": \"https://queue.amazonaws.com/80398EXAMPLE/MyDLQ\", \"target_queue_url\": \"https://queue.amazonaws.com/80398EXAMPLE/MyQueue\"}",
+        "MessageAttributes": {},
+        "Type": "Notification",
+        "UnsubscribeUrl": "EXAMPLE",
+        "TopicArn": "arn:the:temple:knight",
+        "Subject": ""
+      }
+    }
+  ]
+}

--- a/test/unit/sqs-redriver-test.js
+++ b/test/unit/sqs-redriver-test.js
@@ -1,0 +1,244 @@
+import autorestoredSandbox from '@springworks/test-harness/autorestored-sandbox';
+import cloneDeep from 'lodash.clonedeep';
+import redriver from '../../src/sqs-redriver';
+import sqs_instance from '../../src/sqs-instance';
+const sns_event_fixture = require('../../test-util/fixtures/sns-event.json');
+
+const test_queue_params = {
+  source_queue_url: 'https://queue.amazonaws.com/80398EXAMPLE/MyDLQ',
+  target_queue_url: 'https://queue.amazonaws.com/80398EXAMPLE/MyQueue',
+};
+
+describe('test/unit/sqs-redriver-test.js', () => {
+  const sinon_sandbox = autorestoredSandbox();
+
+  describe('redriveMessages', () => {
+
+    describe('with valid params', () => {
+      let params;
+
+      beforeEach(() => {
+        params = createValidParams();
+      });
+
+      describe('with source queue having 2 messages', () => {
+        let receive_message_stub;
+        let send_message_stub;
+        let delete_message_stub;
+        let first_message;
+        let second_message;
+
+        beforeEach('createAwsStubs', () => {
+          receive_message_stub = sinon_sandbox.stub(sqs_instance, 'receiveMessage');
+          send_message_stub = sinon_sandbox.stub(sqs_instance, 'sendMessage');
+          delete_message_stub = sinon_sandbox.stub(sqs_instance, 'deleteMessage');
+        });
+
+        describe('when calls to SQS succeed', () => {
+
+          beforeEach('mockReceiveTwoMessages', () => {
+            first_message = mockIncompleteButSufficientSqsMessage('first');
+            second_message = mockIncompleteButSufficientSqsMessage('second');
+            receive_message_stub.onCall(0).yieldsAsync(null, [first_message]);
+            receive_message_stub.onCall(1).yieldsAsync(null, [second_message]);
+            receive_message_stub.onCall(2).yieldsAsync(null, []);
+          });
+
+          beforeEach('mockSendMessage', () => {
+            const irrelevant_data = {};
+            send_message_stub.yieldsAsync(null, irrelevant_data);
+          });
+
+          beforeEach('mockDeleteMessage', () => {
+            const irrelevant_data = {};
+            delete_message_stub.yieldsAsync(null, irrelevant_data);
+          });
+
+          it('should resolve without value', () => {
+            return redriver.redriveMessages(params).should.be.fulfilledWith(null);
+          });
+
+          it('should fetch 1 message at a time from source queue and iterate 3 times (resolve when not getting any message)', () => {
+            return redriver.redriveMessages(params).then(() => {
+              receive_message_stub.should.have.callCount(3);
+
+              receive_message_stub.getCalls().forEach(call => {
+                call.args[0].should.eql({
+                  MaxNumberOfMessages: 1,
+                  QueueUrl: test_queue_params.source_queue_url,
+                });
+              });
+            });
+          });
+
+          it('should send all messages to target queue', () => {
+            return redriver.redriveMessages(params).then(() => {
+              send_message_stub.should.have.callCount(2);
+
+              send_message_stub.firstCall.args[0].should.eql({
+                MessageBody: first_message.Body,
+                QueueUrl: test_queue_params.target_queue_url,
+              });
+
+              send_message_stub.secondCall.args[0].should.eql({
+                MessageBody: second_message.Body,
+                QueueUrl: test_queue_params.target_queue_url,
+              });
+            });
+          });
+
+          it('should delete each message from source queue', () => {
+            return redriver.redriveMessages(params).then(() => {
+              delete_message_stub.should.have.callCount(2);
+
+              delete_message_stub.firstCall.args[0].should.eql({
+                ReceiptHandle: first_message.ReceiptHandle,
+                QueueUrl: test_queue_params.source_queue_url,
+              });
+
+              delete_message_stub.secondCall.args[0].should.eql({
+                ReceiptHandle: second_message.ReceiptHandle,
+                QueueUrl: test_queue_params.source_queue_url,
+              });
+            });
+          });
+
+        });
+
+        describe('when not possible to fetch messages from source queue', () => {
+          let mock_err;
+
+          beforeEach('mockFailedReceive', () => {
+            mock_err = new Error('Mocked AWS error');
+            receive_message_stub.yieldsAsync(mock_err, null);
+          });
+
+          it('should fail with AWS error', () => {
+            return redriver.redriveMessages(params).should.be.rejectedWith(mock_err);
+          });
+
+          it('should not attempt to add any message to target queue', () => {
+            return redriver.redriveMessages(params).catch(() => {
+              send_message_stub.should.not.be.called();
+            });
+          });
+
+          it('should not delete any message', () => {
+            return redriver.redriveMessages(params).catch(() => {
+              delete_message_stub.should.not.be.called();
+            });
+          });
+
+        });
+
+        describe('when not possible to add messages to target queue', () => {
+          let mock_err;
+
+          beforeEach('mockReceiveOneMessage', () => {
+            first_message = mockIncompleteButSufficientSqsMessage('first');
+            receive_message_stub.onCall(0).yieldsAsync(null, [first_message]);
+            receive_message_stub.onCall(1).yieldsAsync(null, []);
+          });
+
+          beforeEach('mockSendMessage', () => {
+            const irrelevant_data = {};
+            send_message_stub.yieldsAsync(null, irrelevant_data);
+          });
+
+          beforeEach('mockFailedDelete', () => {
+            mock_err = new Error('Mocked AWS error');
+            delete_message_stub.yieldsAsync(mock_err, null);
+          });
+
+          it('should fail with AWS error', () => {
+            return redriver.redriveMessages(params).should.be.rejectedWith(mock_err);
+          });
+
+        });
+
+        describe('when message deletion fails', () => {
+          let mock_err;
+
+          beforeEach('mockReceiveOneMessage', () => {
+            first_message = mockIncompleteButSufficientSqsMessage('first');
+            receive_message_stub.onCall(0).yieldsAsync(null, [first_message]);
+            receive_message_stub.onCall(1).yieldsAsync(null, []);
+          });
+
+          beforeEach('mockFailedSend', () => {
+            mock_err = new Error('Mocked AWS error');
+            send_message_stub.yieldsAsync(mock_err, null);
+          });
+
+          it('should fail with AWS error', () => {
+            return redriver.redriveMessages(params).should.be.rejectedWith(mock_err);
+          });
+
+          it('should not delete any message from source queue', () => {
+            return redriver.redriveMessages(params).catch(() => {
+              delete_message_stub.should.not.be.called();
+            });
+          });
+
+        });
+
+      });
+
+    });
+
+    describe('with invalid params', () => {
+      let params;
+
+      beforeEach(() => {
+        params = createValidParams();
+      });
+
+      describe('missing sns_event', () => {
+
+        beforeEach(() => {
+          delete params.sns_event;
+        });
+
+        it('should fail with error', () => {
+          return redriver.redriveMessages(params).should.be.rejectedWith({
+            code: 422,
+          });
+        });
+
+      });
+
+      describe('with invalid message JSON', () => {
+
+        beforeEach(() => {
+          params.sns_event.Records[0].Sns.Message = {};
+        });
+
+        it('should fail with error', () => {
+          return redriver.redriveMessages(params).should.be.rejectedWith({
+            code: 422,
+          });
+        });
+
+      });
+
+    });
+
+  });
+
+});
+
+function createValidParams() {
+  const sns_event_copy = cloneDeep(sns_event_fixture);
+  sns_event_copy.Records[0].Sns.Message = JSON.stringify(test_queue_params);
+
+  return { sns_event: sns_event_copy };
+}
+
+function mockIncompleteButSufficientSqsMessage(appendix) {
+  return {
+    MessageId: `MessageId-${appendix}`,
+    ReceiptHandle: `ReceiptHandle-${appendix}`,
+    MD5OfBody: `MD5OfBody-${appendix}`,
+    Body: `Body-${appendix}`,
+  };
+}


### PR DESCRIPTION
Lambda handler to redrive messages from one queue to another. Should be triggered by SNS notification with queue params as stringified JSON.

---

# AWS SQS Redriver
Re-drives messages from one SQS queue to another, e.g. to re-process "dead letters".

Meant to be triggered by an SNS notification and run on a Lambda.

## Message Redriver API

### `redriveMessages({ sns_event }) -> Promise`

Moves messages from `source_queue_url` to `target_queue_url`, which should be defined as stringified JSON in the event `Message`.

#### Example

```js
const redriver = require('./build/sqs-redriver');
const dead_letter_queue_url = 'arn:aws:sqs:region:account-id:queuename_dlq';
const target_queue_url = 'arn:aws:sqs:region:account-id:queuename';

const queue_params = {
  source_queue_url: 'https://queue.amazonaws.com/80398EXAMPLE/MyDLQ',
  target_queue_url: 'https://queue.amazonaws.com/80398EXAMPLE/MyQueue',
};

// SNS Event should have Message: JSON.stringify(queue_params)

redriver.redriveMessages({ sns_event: sns_event })
      .then(() => console.log('Success!'))
      .catch(err => console.log('Failed to redrive messages: %j', err));
```

#### IAM access to queues

`source_queue_url`

- sqs:ChangeMessageVisibility
- sqs:ReceiveMessage
- sqs:DeleteMessage

`target_queue_url`

- sqs:SendMessage

## License

MIT.
