### PR TITLE
feat: Use SQS long-polling when receiving messages

### DIFF
--- a/src/sqs-redriver.js
+++ b/src/sqs-redriver.js
@@ -50,6 +50,7 @@ function fetchMessagesUntilEmpty({ source_queue_url, target_queue_url }) {
 }
 
 function redriveMessage({ sqs_message, source_queue_url, target_queue_url }) {
+  console.log('Redriving message with receipt handle %s...', sqs_message.ReceiptHandle);
   return sendMessage({ message_body: sqs_message.Body, target_queue_url })
       .then(() => deleteMessage({ receipt_handle: sqs_message.ReceiptHandle, source_queue_url }))
       .then(() => console.log(`Message moved from ${source_queue_url} to ${target_queue_url}`))
@@ -61,6 +62,7 @@ function receiveMessage({ source_queue_url }) {
     sqs_instance.receiveMessage({
       MaxNumberOfMessages: 1,
       QueueUrl: source_queue_url,
+      WaitTimeSeconds: 20,
     }, (err, messages) => {
       if (err) {
         reject(err);
@@ -72,6 +74,7 @@ function receiveMessage({ source_queue_url }) {
         return;
       }
 
+      console.log('No more messages received in queue...');
       resolve(null);
     });
   });

--- a/test/unit/sqs-redriver-test.js
+++ b/test/unit/sqs-redriver-test.js
@@ -58,7 +58,7 @@ describe('test/unit/sqs-redriver-test.js', () => {
             return redriver.redriveMessages(params).should.be.fulfilledWith(null);
           });
 
-          it('should fetch 1 message at a time from source queue and iterate 3 times (resolve when not getting any message)', () => {
+          it('should long poll 1 message at a time from source queue and iterate 3 times (resolve when not getting any message)', () => {
             return redriver.redriveMessages(params).then(() => {
               receive_message_stub.should.have.callCount(3);
 
@@ -66,6 +66,7 @@ describe('test/unit/sqs-redriver-test.js', () => {
                 call.args[0].should.eql({
                   MaxNumberOfMessages: 1,
                   QueueUrl: test_queue_params.source_queue_url,
+                  WaitTimeSeconds: 20,
                 });
               });
             });


### PR DESCRIPTION
feat: Use SQS long-polling when receiving messages

Will reduce the risk of getting empty results, which would effectively stop the redrive script.

See http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html for more details.