### PR TITLE
fix: Expect receiveMessage() response to match the one from AWS

### DIFF
--- a/src/sqs-redriver.js
+++ b/src/sqs-redriver.js
@@ -63,14 +63,14 @@ function receiveMessage({ source_queue_url }) {
       MaxNumberOfMessages: 1,
       QueueUrl: source_queue_url,
       WaitTimeSeconds: 20,
-    }, (err, messages) => {
+    }, (err, data) => {
       if (err) {
         reject(err);
         return;
       }
 
-      if (messages.length) {
-        resolve(messages[0]);
+      if (data.Messages && data.Messages.length) {
+        resolve(data.Messages[0]);
         return;
       }
 

--- a/test/unit/sqs-redriver-test.js
+++ b/test/unit/sqs-redriver-test.js
@@ -39,9 +39,9 @@ describe('test/unit/sqs-redriver-test.js', () => {
           beforeEach('mockReceiveTwoMessages', () => {
             first_message = mockIncompleteButSufficientSqsMessage('first');
             second_message = mockIncompleteButSufficientSqsMessage('second');
-            receive_message_stub.onCall(0).yieldsAsync(null, [first_message]);
-            receive_message_stub.onCall(1).yieldsAsync(null, [second_message]);
-            receive_message_stub.onCall(2).yieldsAsync(null, []);
+            receive_message_stub.onCall(0).yieldsAsync(null, mockReceivedMessageResponse(first_message));
+            receive_message_stub.onCall(1).yieldsAsync(null, mockReceivedMessageResponse(second_message));
+            receive_message_stub.onCall(2).yieldsAsync(null, mockReceivedMessageResponse(null));
           });
 
           beforeEach('mockSendMessage', () => {
@@ -137,8 +137,8 @@ describe('test/unit/sqs-redriver-test.js', () => {
 
           beforeEach('mockReceiveOneMessage', () => {
             first_message = mockIncompleteButSufficientSqsMessage('first');
-            receive_message_stub.onCall(0).yieldsAsync(null, [first_message]);
-            receive_message_stub.onCall(1).yieldsAsync(null, []);
+            receive_message_stub.onCall(0).yieldsAsync(null, mockReceivedMessageResponse(first_message));
+            receive_message_stub.onCall(1).yieldsAsync(null, mockReceivedMessageResponse(null));
           });
 
           beforeEach('mockSendMessage', () => {
@@ -162,8 +162,8 @@ describe('test/unit/sqs-redriver-test.js', () => {
 
           beforeEach('mockReceiveOneMessage', () => {
             first_message = mockIncompleteButSufficientSqsMessage('first');
-            receive_message_stub.onCall(0).yieldsAsync(null, [first_message]);
-            receive_message_stub.onCall(1).yieldsAsync(null, []);
+            receive_message_stub.onCall(0).yieldsAsync(null, mockReceivedMessageResponse(first_message));
+            receive_message_stub.onCall(1).yieldsAsync(null, mockReceivedMessageResponse(null));
           });
 
           beforeEach('mockFailedSend', () => {
@@ -242,4 +242,9 @@ function mockIncompleteButSufficientSqsMessage(appendix) {
     MD5OfBody: `MD5OfBody-${appendix}`,
     Body: `Body-${appendix}`,
   };
+}
+
+function mockReceivedMessageResponse(message) {
+  const messages = message ? [message] : [];
+  return { Messages: messages };
 }


### PR DESCRIPTION
fix: Expect receiveMessage() response to match the one from AWS

The response was misunderstood, it actually returns an Object with a `Messages` property rather than an array of `messages`.

See http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/SQS.html#receiveMessage-property